### PR TITLE
[WIP] Add support for `approx.auto_quantize`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,14 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Build wheels
+    - name: Setup dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install poetry
-        poetry build
+        poetry install
+    - name: Run tests
+      run: |
+          poetry run pytest
+    - name: Build wheels
+      run: |
+          poetry build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build the wheels
+    name: CI Workflow
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: CI Workflow
+name: Documentation Workflow
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,11 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install poetry
         poetry install
-    - name: Check formatting
+    - name: Check with black
       run: poetry run black --check approx/
+    - name: Check with pycln
+      run: poetry run pycln --check approx/
+    - name: Check with isort
+      run: poetry run isort --check approx/
     - name: Mypy analysis
       run: poetry run mypy approx/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        poetry install
+    - name: Run tests
+      run: |
+          poetry run pytest
+    - name: Build wheels
+      run: |
+          poetry build
+    - name: Build wheels
+      run: |
+          poetry build
+    - name: Publish Package
+      run: |
+        python -m poetry publish --username=${{ secrets.PYPIUSERNAME }} --password=${{ secrets.PYPIPASSWORD }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,11 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.800
+    hooks:
+      - id: mypy
+        name: mypy
+        files: ^approx/
+        exclude: (/tests/)|(/docs/)|(/examples/)
+        args: ["--ignore-missing-imports"]

--- a/approx/__init__.py
+++ b/approx/__init__.py
@@ -1,7 +1,10 @@
-from approx.core.api import auto_cast_all, auto_set_backend, auto_quantize, \
-    auto_set_device
 from approx.core._vars import _APPROX_BACKEND, _APPROX_DEVICE, backend, device
-
+from approx.core.api import (
+    auto_cast_all,
+    auto_quantize,
+    auto_set_backend,
+    auto_set_device,
+)
 
 # Please keep this sorted
 __all__ = [
@@ -10,7 +13,7 @@ __all__ = [
     "auto_set_backend",
     "auto_set_device",
     "backend",
-    "device"
+    "device",
 ]
 
 assert __all__ == sorted(__all__), "Public API methods are not sorted!"

--- a/approx/__init__.py
+++ b/approx/__init__.py
@@ -1,14 +1,8 @@
 from approx.core._vars import backend, device
-from approx.core.api import (
-    auto_cast_all,
-    auto_quantize,
-    auto_set_backend,
-    auto_set_device,
-)
+from approx.core.api import auto_quantize, auto_set_backend, auto_set_device
 
 # Please keep this sorted
 __all__ = [
-    "auto_cast_all",
     "auto_quantize",
     "auto_set_backend",
     "auto_set_device",

--- a/approx/__init__.py
+++ b/approx/__init__.py
@@ -1,5 +1,7 @@
-from approx.core.api import auto_cast_all, auto_set_backend, auto_quantize,\
+from approx.core.api import auto_cast_all, auto_set_backend, auto_quantize, \
     auto_set_device
+from approx.core._vars import _APPROX_BACKEND, _APPROX_DEVICE, backend, device
+
 
 # Please keep this sorted
 __all__ = [
@@ -7,6 +9,8 @@ __all__ = [
     "auto_quantize",
     "auto_set_backend",
     "auto_set_device",
+    "backend",
+    "device"
 ]
 
 assert __all__ == sorted(__all__), "Public API methods are not sorted!"

--- a/approx/__init__.py
+++ b/approx/__init__.py
@@ -1,6 +1,12 @@
-from approx.core.api import auto_cast_all, auto_select_backend
+from approx.core.api import auto_cast_all, auto_set_backend, auto_quantize,\
+    auto_set_device
 
+# Please keep this sorted
 __all__ = [
     "auto_cast_all",
-    "auto_select_backend",
+    "auto_quantize",
+    "auto_set_backend",
+    "auto_set_device",
 ]
+
+assert __all__ == sorted(__all__), "Public API methods are not sorted!"

--- a/approx/__init__.py
+++ b/approx/__init__.py
@@ -1,4 +1,4 @@
-from approx.core._vars import _APPROX_BACKEND, _APPROX_DEVICE, backend, device
+from approx.core._vars import backend, device
 from approx.core.api import (
     auto_cast_all,
     auto_quantize,

--- a/approx/core/_vars.py
+++ b/approx/core/_vars.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from approx.core.backend._backend import BackendEngine
 from approx.core.device._device import DeviceEngine
 

--- a/approx/core/_vars.py
+++ b/approx/core/_vars.py
@@ -1,0 +1,5 @@
+from typing import Optional
+from approx.core.backend._backend import BackendEngine
+
+_APPROX_BACKEND: Optional[BackendEngine] = None
+

--- a/approx/core/_vars.py
+++ b/approx/core/_vars.py
@@ -7,11 +7,11 @@ _APPROX_BACKEND: Optional[BackendEngine] = None
 _APPROX_DEVICE: Optional[DeviceEngine] = None
 
 
-def backend() -> BackendEngine:
+def backend() -> Optional[BackendEngine]:
     global _APPROX_BACKEND
     return _APPROX_BACKEND
 
 
-def device() -> DeviceEngine:
+def device() -> Optional[DeviceEngine]:
     global _APPROX_DEVICE
     return _APPROX_DEVICE

--- a/approx/core/_vars.py
+++ b/approx/core/_vars.py
@@ -1,5 +1,16 @@
 from typing import Optional
 from approx.core.backend._backend import BackendEngine
+from approx.core.device._device import DeviceEngine
 
 _APPROX_BACKEND: Optional[BackendEngine] = None
+_APPROX_DEVICE: Optional[DeviceEngine] = None
 
+
+def backend() -> BackendEngine:
+    global _APPROX_BACKEND
+    return _APPROX_BACKEND
+
+
+def device() -> DeviceEngine:
+    global _APPROX_DEVICE
+    return _APPROX_DEVICE

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -1,8 +1,21 @@
 """
 Contains stuff to be exported in the public API.
 """
-from approx.core.backend.common import BackendEngine, auto_select_backend
+from approx.core.backend.common import auto_select_backend
 from approx.core.device.common import DeviceEngine, auto_select_device
+from approx.core._vars import _APPROX_BACKEND
+
+
+def auto_quantize(model, pretrained=True):
+    """Turns a normal model into a quantized model, using an appropriate backend
+
+    Args:
+        model: The model to quantize.
+        pretrained: Whether this model is pretrained
+    """
+
+    qmodel = _APPROX_BACKEND.auto_quantize(model, pretrained)
+    return qmodel
 
 
 def auto_cast_all(*args) -> None:
@@ -15,13 +28,14 @@ def auto_cast_all(*args) -> None:
     pass
 
 
-def auto_set_backend() -> BackendEngine:
+def auto_set_backend() -> None:
     """Automatically selects an appropriate backend to utilize.
 
     Returns:
-        BackendEngine: An instance of whatever backend is most appropriate.
+        None.
     """
-    return auto_select_backend()
+    global _APPROX_BACKEND
+    _APPROX_BACKEND = auto_select_backend()
 
 
 def auto_set_device() -> DeviceEngine:

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -1,12 +1,14 @@
 """
 Contains stuff to be exported in the public API.
 """
+from typing import Any
+
 from approx.core import _vars
 from approx.core.backend.common import auto_select_backend
 from approx.core.device.common import auto_select_device
 
 
-def auto_quantize(model, pretrained: bool = True):
+def auto_quantize(model: Any, pretrained: bool = True) -> Any:
     """Turns a normal model into a quantized model, using an appropriate backend
 
     Args:
@@ -22,7 +24,7 @@ def auto_quantize(model, pretrained: bool = True):
     return qmodel
 
 
-def auto_cast_all(*args) -> None:
+def auto_cast_all(*args: Any) -> None:
     """Automatically casts any tensors for automatic quantization
 
     Notes:

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -3,7 +3,7 @@ Contains stuff to be exported in the public API.
 """
 from approx.core.backend.common import auto_select_backend
 from approx.core.device.common import DeviceEngine, auto_select_device
-from approx.core._vars import _APPROX_BACKEND
+from approx.core import _vars
 
 
 def auto_quantize(model, pretrained=True):
@@ -14,7 +14,7 @@ def auto_quantize(model, pretrained=True):
         pretrained: Whether this model is pretrained
     """
 
-    qmodel = _APPROX_BACKEND.auto_quantize(model, pretrained)
+    qmodel = _vars._APPROX_BACKEND.auto_quantize(model, pretrained)
     return qmodel
 
 
@@ -29,19 +29,19 @@ def auto_cast_all(*args) -> None:
 
 
 def auto_set_backend() -> None:
-    """Automatically selects an appropriate backend to utilize.
+    """Automatically sets an appropriate backend for `approx` to use.
 
     Returns:
         None.
     """
-    global _APPROX_BACKEND
-    _APPROX_BACKEND = auto_select_backend()
+
+    _vars._APPROX_BACKEND = auto_select_backend()
 
 
-def auto_set_device() -> DeviceEngine:
-    """Automatically selects an appropriate device to utilize.
+def auto_set_device() -> None:
+    """Automatically sets an appropriate device for `approx` to use.
 
     Returns:
-        DeviceEngine: An instance of whatever device is most appropriate.
+        None.
     """
-    return auto_select_device()
+    _vars._APPROX_DEVICE = auto_select_device()

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -3,7 +3,7 @@ Contains stuff to be exported in the public API.
 """
 from approx.core import _vars
 from approx.core.backend.common import auto_select_backend
-from approx.core.device.common import DeviceEngine, auto_select_device
+from approx.core.device.common import auto_select_device
 
 
 def auto_quantize(model, pretrained: bool = True):
@@ -13,7 +13,11 @@ def auto_quantize(model, pretrained: bool = True):
         model: The model to quantize.
         pretrained: Whether this model is pretrained
     """
-
+    if _vars._APPROX_BACKEND is None:
+        raise ValueError(
+            "No backend has been set. "
+            "Please call `approx.auto_set_backend()`."
+        )
     qmodel = _vars._APPROX_BACKEND.auto_quantize(model, pretrained)
     return qmodel
 

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -6,7 +6,7 @@ from approx.core.backend.common import auto_select_backend
 from approx.core.device.common import DeviceEngine, auto_select_device
 
 
-def auto_quantize(model, pretrained=True):
+def auto_quantize(model, pretrained: bool = True):
     """Turns a normal model into a quantized model, using an appropriate backend
 
     Args:
@@ -20,6 +20,9 @@ def auto_quantize(model, pretrained=True):
 
 def auto_cast_all(*args) -> None:
     """Automatically casts any tensors for automatic quantization
+
+    Notes:
+        This function is deprecated and planned for removal.
 
     Returns:
         None:

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -24,20 +24,6 @@ def auto_quantize(model: Any, pretrained: bool = True) -> Any:
     return qmodel
 
 
-def auto_cast_all(*args: Any) -> None:
-    """Automatically casts any tensors for automatic quantization
-
-    Notes:
-        This function is deprecated and planned for removal.
-
-    Returns:
-        None:
-    """
-    raise NotImplementedError(
-        "This function is deprecated and planned for removal."
-    )
-
-
 def auto_set_backend() -> None:
     """Automatically sets an appropriate backend for `approx` to use.
 

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -33,8 +33,7 @@ def auto_cast_all(*args: Any) -> None:
     Returns:
         None:
     """
-    # todo: unimplemented
-    pass
+    raise NotImplementedError("This function is deprecated and planned for removal.")
 
 
 def auto_set_backend() -> None:

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -1,19 +1,17 @@
 """
 Contains stuff to be exported in the public API.
 """
-from contextlib import contextmanager
-
 from approx.core.backend.common import BackendEngine, auto_select_backend
 from approx.core.device.common import DeviceEngine, auto_select_device
 
 
-@contextmanager
-def auto_cast_all() -> None:
-    """Context manager that automatically casts and applies quantization to
-        any tensors created within the context.
+def auto_cast_all(*args) -> None:
+    """Automatically casts any tensors for automatic quantization
+
     Returns:
-        ContextManager: pass
+        None:
     """
+    # todo: unimplemented
     pass
 
 

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -33,7 +33,9 @@ def auto_cast_all(*args: Any) -> None:
     Returns:
         None:
     """
-    raise NotImplementedError("This function is deprecated and planned for removal.")
+    raise NotImplementedError(
+        "This function is deprecated and planned for removal."
+    )
 
 
 def auto_set_backend() -> None:

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -1,9 +1,9 @@
 """
 Contains stuff to be exported in the public API.
 """
+from approx.core import _vars
 from approx.core.backend.common import auto_select_backend
 from approx.core.device.common import DeviceEngine, auto_select_device
-from approx.core import _vars
 
 
 def auto_quantize(model, pretrained=True):

--- a/approx/core/api.py
+++ b/approx/core/api.py
@@ -24,19 +24,6 @@ def auto_quantize(model: Any, pretrained: bool = True) -> Any:
     return qmodel
 
 
-def auto_cast_all(*args: Any) -> None:
-    """Automatically casts any tensors for automatic quantization
-
-    Notes:
-        This function is deprecated and planned for removal.
-
-    Returns:
-        None:
-    """
-    # todo: unimplemented
-    pass
-
-
 def auto_set_backend() -> None:
     """Automatically sets an appropriate backend for `approx` to use.
 

--- a/approx/core/backend/_backend.py
+++ b/approx/core/backend/_backend.py
@@ -62,20 +62,24 @@ class PyTorchBackend(BackendEngine):
             The quantized model
         """
         if pretrained:
-            if next(model.parameters()).device.type == "cuda":
-                model.cpu()
+            model.cpu()
             qmodel = self.module.quantization.quantize_dynamic(
                 model, # the original model
                 # a set of layers to dynamically quantize
                 {
-                    self.module.nn.Linear,
-                    self.module.nn.LSTM,
-                    self.module.nn.GRU,
-                    self.module.nn.LSTMCell,
-                    self.module.nn.RNNCell,
-                    self.module.nn.GRUCell,
-                    self.module.nn.Conv2d,
-                    self.module.nn.Conv3d,
+                    self.module.nn.Linear: self.module.quantization.default_dynamic_qconfig,
+                    self.module.nn.LSTM: self.module.quantization.default_dynamic_qconfig,
+                    self.module.nn.GRU: self.module.quantization.default_dynamic_qconfig,
+                    self.module.nn.LSTMCell: self.module.quantization.default_dynamic_qconfig,
+                    self.module.nn.RNNCell: self.module.quantization.default_dynamic_qconfig,
+                    self.module.nn.GRUCell: self.module.quantization.default_dynamic_qconfig,
+
+                    # TODO(sudomaze): needed to specify the dtype, https://github.com/pytorch/pytorch/issues/65185
+                    self.module.nn.EmbeddingBag: self.module.quantization.qconfig.float_qparams_weight_only_qconfig,
+
+                    # Not supported yet
+                    # self.module.nn.Conv2d,
+                    # self.module.nn.Conv3d,
                 },
                 dtype=self.module.qint8, # the target dtype for quantized weights
             )

--- a/approx/core/backend/_backend.py
+++ b/approx/core/backend/_backend.py
@@ -3,11 +3,13 @@ Backend engine definitions
 """
 import abc
 import enum
+from typing import Any
 
 
 class BackendType(enum.Enum):
     """Backend type enum"""
 
+    UNKNOWN = -1
     TORCH = 0
     NUMPY = 1
 
@@ -15,7 +17,7 @@ class BackendType(enum.Enum):
 class BackendNotSupported(Exception):
     """Backend not supported exception"""
 
-    def __init__(self, backend):
+    def __init__(self, backend: str) -> None:
         """
         Args:
             backend (str): backend name
@@ -26,30 +28,29 @@ class BackendNotSupported(Exception):
 class BackendEngine(abc.ABC):
     """Backend engine abstract class"""
 
-    def __init__(self):
-        self.type = None
-        self.module = None
+    def __init__(self) -> None:
+        super().__init__()
+        self.type: BackendType = BackendType.UNKNOWN
+        self.module: Any = None
 
-    def auto_quantize(self, model, pretrained: bool):
+    def auto_quantize(self, model: Any, pretrained: bool) -> Any:
         raise NotImplementedError("Need to implement this method")
 
-    def __str__(self):
-        if self.type:
-            return self.type.name.lower()
-        return "unknown"
+    def __str__(self) -> str:
+        return self.type.name.lower()
 
 
 class PyTorchBackend(BackendEngine):
     """PyTorch backend engine"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         import torch
 
         self.type = BackendType.TORCH
         self.module = torch
 
-    def auto_quantize(self, model, pretrained: bool):
+    def auto_quantize(self, model: Any, pretrained: bool) -> Any:
         """
         Uses pytorch's dynamic quantization to convert some floating-point
         `nn.Module` to `qint8`
@@ -79,7 +80,7 @@ class PyTorchBackend(BackendEngine):
 class NumPyBackend(BackendEngine):
     """NumPy backend engine"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         import numpy
 

--- a/approx/core/backend/_backend.py
+++ b/approx/core/backend/_backend.py
@@ -61,13 +61,19 @@ class PyTorchBackend(BackendEngine):
             The quantized model
         """
         if pretrained:
-            qmodel = self.module.quantization.quantize_dynamic(model, {
-                # todo: this is definitely not enough
-                self.module.nn.Linear,
-                self.module.nn.Conv2d
-            }, dtype=self.module.qint8)
+            qmodel = self.module.quantization.quantize_dynamic(
+                model,
+                {
+                    # todo: this is definitely not enough
+                    self.module.nn.Linear,
+                    self.module.nn.Conv2d,
+                },
+                dtype=self.module.qint8,
+            )
             return qmodel
-        raise NotImplementedError("Currently not implemented for non-pretrained models")
+        raise NotImplementedError(
+            "Currently not implemented for non-pretrained models"
+        )
 
 
 class NumPyBackend(BackendEngine):

--- a/approx/core/backend/_backend.py
+++ b/approx/core/backend/_backend.py
@@ -30,6 +30,9 @@ class BackendEngine(abc.ABC):
         self.type = None
         self.module = None
 
+    def auto_quantize(self, model, pretrained: bool):
+        raise NotImplementedError("Need to implement this method")
+
     def __str__(self):
         if self.type:
             return self.type.name.lower()
@@ -40,16 +43,38 @@ class PyTorchBackend(BackendEngine):
     """PyTorch backend engine"""
 
     def __init__(self):
+        super().__init__()
         import torch
 
         self.type = BackendType.TORCH
         self.module = torch
+
+    def auto_quantize(self, model, pretrained: bool):
+        """
+        Uses pytorch's dynamic quantization to convert some floating-point
+        `nn.Module` to `qint8`
+        Args:
+            model: The model to quantize.
+            pretrained: Whether the model is pretrained.
+
+        Returns:
+            The quantized model
+        """
+        if pretrained:
+            qmodel = self.module.quantization.quantize_dynamic(model, {
+                # todo: this is definitely not enough
+                self.module.nn.Linear,
+                self.module.nn.Conv2d
+            }, dtype=self.module.qint8)
+            return qmodel
+        raise NotImplementedError("Currently not implemented for non-pretrained models")
 
 
 class NumPyBackend(BackendEngine):
     """NumPy backend engine"""
 
     def __init__(self):
+        super().__init__()
         import numpy
 
         self.type = BackendType.NUMPY

--- a/approx/core/backend/_backend.py
+++ b/approx/core/backend/_backend.py
@@ -62,14 +62,22 @@ class PyTorchBackend(BackendEngine):
             The quantized model
         """
         if pretrained:
+            if next(model.parameters()).device.type == "cuda":
+                model.cpu()
             qmodel = self.module.quantization.quantize_dynamic(
-                model,
+                model, # the original model
+                # a set of layers to dynamically quantize
                 {
-                    # todo: this is definitely not enough
                     self.module.nn.Linear,
+                    self.module.nn.LSTM,
+                    self.module.nn.GRU,
+                    self.module.nn.LSTMCell,
+                    self.module.nn.RNNCell,
+                    self.module.nn.GRUCell,
                     self.module.nn.Conv2d,
+                    self.module.nn.Conv3d,
                 },
-                dtype=self.module.qint8,
+                dtype=self.module.qint8, # the target dtype for quantized weights
             )
             return qmodel
         raise NotImplementedError(

--- a/approx/core/backend/_backend.py
+++ b/approx/core/backend/_backend.py
@@ -64,7 +64,7 @@ class PyTorchBackend(BackendEngine):
         if pretrained:
             model.cpu()
             qmodel = self.module.quantization.quantize_dynamic(
-                model, # the original model
+                model,  # the original model
                 # a set of layers to dynamically quantize
                 {
                     self.module.nn.Linear: self.module.quantization.default_dynamic_qconfig,
@@ -73,15 +73,13 @@ class PyTorchBackend(BackendEngine):
                     self.module.nn.LSTMCell: self.module.quantization.default_dynamic_qconfig,
                     self.module.nn.RNNCell: self.module.quantization.default_dynamic_qconfig,
                     self.module.nn.GRUCell: self.module.quantization.default_dynamic_qconfig,
-
                     # TODO(sudomaze): needed to specify the dtype, https://github.com/pytorch/pytorch/issues/65185
                     self.module.nn.EmbeddingBag: self.module.quantization.qconfig.float_qparams_weight_only_qconfig,
-
                     # Not supported yet
                     # self.module.nn.Conv2d,
                     # self.module.nn.Conv3d,
                 },
-                dtype=self.module.qint8, # the target dtype for quantized weights
+                dtype=self.module.qint8,  # the target dtype for quantized weights
             )
             return qmodel
         raise NotImplementedError(

--- a/approx/core/backend/common.py
+++ b/approx/core/backend/common.py
@@ -31,11 +31,15 @@ def auto_select_backend() -> BackendEngine:
 
     preferred_backends = ["TORCH"]
     for backend_type in preferred_backends:
+        if backend_type.lower() == "unknown":
+            continue
         if importlib.util.find_spec(backend_type.lower()) is not None:
             return set_backend(BackendType[backend_type])
 
     # fallback
     for backend_type in backend_types:
+        if backend_type.lower() == "unknown":
+            continue
         if importlib.util.find_spec(backend_type.lower()) is not None:
             return set_backend(BackendType[backend_type])
 
@@ -69,4 +73,4 @@ def set_backend(choice: BackendType) -> BackendEngine:
         return NumPyBackend()
 
     # if asked for a backend that doesn't exist, raise an error
-    raise BackendNotSupported(choice)
+    raise BackendNotSupported(str(choice))

--- a/approx/core/backend/common.py
+++ b/approx/core/backend/common.py
@@ -28,6 +28,13 @@ def auto_select_backend() -> BackendEngine:
             and not attr.startswith("__")
         )
     ]
+
+    preferred_backends = ["TORCH"]
+    for backend_type in preferred_backends:
+        if importlib.util.find_spec(backend_type.lower()) is not None:
+            return set_backend(BackendType[backend_type])
+
+    # fallback
     for backend_type in backend_types:
         if importlib.util.find_spec(backend_type.lower()) is not None:
             return set_backend(BackendType[backend_type])

--- a/approx/core/device/__init__.py
+++ b/approx/core/device/__init__.py
@@ -1,1 +1,4 @@
+"""
+device initialization
+"""
 from approx.core.device.common import auto_select_device, set_device

--- a/approx/core/device/_device.py
+++ b/approx/core/device/_device.py
@@ -8,6 +8,7 @@ import enum
 class DeviceType(enum.Enum):
     """Device type enum"""
 
+    UNKNOWN = 0
     CPU = 0
     CUDA = 1  # CUDA
     XLA = 2  # XLA / TPU
@@ -16,7 +17,7 @@ class DeviceType(enum.Enum):
 class DeviceNotSupported(Exception):
     """Device not supported exception"""
 
-    def __init__(self, device):
+    def __init__(self, device: str):
         """
         Args:
             device (str): device name
@@ -27,31 +28,33 @@ class DeviceNotSupported(Exception):
 class DeviceEngine(abc.ABC):
     """Device engine abstract class"""
 
-    def __init__(self):
-        self.type = None
+    def __init__(self) -> None:
+        super().__init__()
+        self.type: DeviceType = DeviceType.UNKNOWN
 
-    def __str__(self):
-        if self.type:
-            return self.type.name.lower()
-        return "unknown"
+    def __str__(self) -> str:
+        return self.type.name.lower()
 
 
 class CPUDevice(DeviceEngine):
     """CPU device engine"""
 
-    def __init__(self):
-        self.type = DeviceType.CPU
+    def __init__(self) -> None:
+        super().__init__()
+        self.type: DeviceType = DeviceType.CPU
 
 
 class CUDADevice(DeviceEngine):
     """CUDA device engine"""
 
-    def __init__(self):
-        self.type = DeviceType.CUDA
+    def __init__(self) -> None:
+        super().__init__()
+        self.type: DeviceType = DeviceType.CUDA
 
 
 class XLADevice(DeviceEngine):
     """XLA device engine"""
 
-    def __init__(self):
-        self.type = DeviceType.XLA
+    def __init__(self) -> None:
+        super().__init__()
+        self.type: DeviceType = DeviceType.XLA

--- a/approx/core/device/common.py
+++ b/approx/core/device/common.py
@@ -60,7 +60,7 @@ def set_device(choice: DeviceType) -> DeviceEngine:
 
     # if asked for a device that doesn't exist, raise an error
     elif choice not in DeviceType:
-        raise DeviceNotSupported(choice)
+        raise DeviceNotSupported(str(choice))
 
     # if no device was asked for, set device to CPU
     else:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,14 +4,14 @@ We welcome all contributors! Please visit our issues page to have a look around.
 
 
 ## Dev setup
-We hope that you will find `approx` extremely easy to set up. After cloning our 
+We hope that you will find `approx` extremely easy to set up. After cloning our
 repository, you can simply run
 
 ```bash
 # to install project dependencies
 poetry install
 # to install pre-commit for linting
-pre-commit install 
+pre-commit install
 ```
 
 and start working on the libs immediately!

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,20 +1,17 @@
  # Contributing to `approx`
 
-We welcome all contributors! Please visit our issues page
-to have a look around.
+We welcome all contributors! Please visit our issues page to have a look around.
 
 
 ## Dev setup
-We hope that you will find `approx` extremely easy to set up.
-After cloning our repository, you can simply run
+We hope that you will find `approx` extremely easy to set up. After cloning our 
+repository, you can simply run
 
 ```bash
+# to install project dependencies
 poetry install
+# to install pre-commit for linting
+pre-commit install 
 ```
 
-and start working on the libs immediately.
-
-
-## Linting
-
-Please run `pre-commit` before you commit any changes.
+and start working on the libs immediately!

--- a/examples/scripts/mnist_torch.py
+++ b/examples/scripts/mnist_torch.py
@@ -44,14 +44,8 @@ if __name__ == "__main__":
     test_loader = data.DataLoader(mnist_test, batch_size=512, shuffle=True)
 
     model = BasicNN()
-    model = approx.auto_quantize(model, pretrained=True)
 
-    # qmodel = torch.quantization.quantize_dynamic(model, {nn.Linear, nn.Conv2d}, dtype=torch.qint8)
-    # qmodel.to('cuda')
-    print(model)
-    exit(0)
-
-    # model.to("cuda")
+    model.to("cuda")
     optim = torch.optim.SGD(model.parameters(), lr=0.001)
     loss = nn.CrossEntropyLoss().to("cuda")
 
@@ -60,7 +54,6 @@ if __name__ == "__main__":
     for epoch_it in range(num_epochs):
         prog = tqdm(enumerate(train_loader), total=len(train_loader))
         for batch_num, (features, labels) in prog:
-            # approx.auto_cast_all(features, labels)
             features = features.to("cuda")
             labels = labels.to("cuda")
             logits = model(features)
@@ -73,3 +66,11 @@ if __name__ == "__main__":
                 {"epoch": epoch_it + 1, "loss": loss_value.item()}
             )
         prog.close()
+
+    print("Before quantization -------------")
+    print(model)
+
+    model = approx.auto_quantize(model, pretrained=True)
+
+    print("After quantization -------------")
+    print(model)

--- a/examples/scripts/mnist_torch.py
+++ b/examples/scripts/mnist_torch.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 import approx
 
-approx.auto_select_backend()
+approx.auto_set_backend()
 
 
 class BasicNN(nn.Module):
@@ -32,26 +32,35 @@ class BasicNN(nn.Module):
         return logits
 
 
-mnist_train = torchvision.datasets.MNIST(
-    root="./datasets", train=True, download=True, transform=ToTensor()
-)
-mnist_test = torchvision.datasets.MNIST(
-    root="./datasets", train=False, download=True, transform=ToTensor()
-)
+if __name__ == "__main__":
+    mnist_train = torchvision.datasets.MNIST(
+        root="./datasets", train=True, download=True, transform=ToTensor()
+    )
+    mnist_test = torchvision.datasets.MNIST(
+        root="./datasets", train=False, download=True, transform=ToTensor()
+    )
 
-train_loader = data.DataLoader(mnist_train, batch_size=512, shuffle=True)
-test_loader = data.DataLoader(mnist_test, batch_size=512, shuffle=True)
+    train_loader = data.DataLoader(mnist_train, batch_size=512, shuffle=True)
+    test_loader = data.DataLoader(mnist_test, batch_size=512, shuffle=True)
 
-model = BasicNN()
-model.to("cuda")
-optim = torch.optim.SGD(model.parameters(), lr=0.01)
-loss = nn.CrossEntropyLoss().to("cuda")
+    model = BasicNN()
+    model = approx.auto_quantize(model, pretrained=True)
 
-with approx.auto_cast_all():
-    num_epochs = 10
+    # qmodel = torch.quantization.quantize_dynamic(model, {nn.Linear, nn.Conv2d}, dtype=torch.qint8)
+    # qmodel.to('cuda')
+    print(model)
+    exit(0)
+
+    # model.to("cuda")
+    optim = torch.optim.SGD(model.parameters(), lr=0.001)
+    loss = nn.CrossEntropyLoss().to("cuda")
+
+    model.train()
+    num_epochs = 2
     for epoch_it in range(num_epochs):
         prog = tqdm(enumerate(train_loader), total=len(train_loader))
         for batch_num, (features, labels) in prog:
+            # approx.auto_cast_all(features, labels)
             features = features.to("cuda")
             labels = labels.to("cuda")
             logits = model(features)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,3 +8,6 @@ markdown_extensions:
 plugins:
   - search
   - mkdocstrings
+
+watch:
+  - approx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ mkdocstrings = {extras = ["python"], version = "^0.19.0"}
 mkdocs-material = "^8.3.9"
 pycln = "^2.0.1"
 ipykernel = "^6.15.1"
+torchvision = "^0.13.0"
 
 [tool.mypy]
 files = ["^approx/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,18 @@ description = "Too lazy to quantize? Don't worry! Just tell approx to cast every
 license = "Apache-2.0"
 authors = ["sudomaze", "xiurobert"]
 readme = 'README.md'
+homepage = "https://github.com/approx-ml/approx"
+repository = "https://github.com/approx-ml/approx"
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "License :: OSI Approved :: Apache-2.0 License",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3.7",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 
 [tool.poetry.dependencies]
 python = "^3.7.13"
@@ -27,9 +39,13 @@ pycln = "^2.0.1"
 ipykernel = "^6.15.1"
 
 [tool.mypy]
-files = ["approx"]
-show_error_codes = true
+files = ["^approx/"]
 pretty = true
+strict = true
+# show_error_codes = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+# ignore_missing_imports = true
+exclude = "(/tests/)|(/docs/)|(/examples/)"
 
 [tool.pytest]
 # log_cli = true

--- a/tests/components/core/test_backend.py
+++ b/tests/components/core/test_backend.py
@@ -1,0 +1,252 @@
+"""
+Test Backend
+"""
+
+import pytest
+import torch
+
+PYTORCH_QUANTIZED_MODULES = [
+    # quantized modules
+    'DynamicQuantizedLinear',
+    'DynamicQuantizedRNNCell',
+    'DynamicQuantizedLSTMCell',
+    'DynamicQuantizedGRUCell',
+
+    # quantized operations
+    'QuantizedEmbeddingBag',
+]
+def assert_children(m: torch.nn.Module):
+    children = dict(m.named_children())
+    if children == {}:
+        if (
+            hasattr(m, '_get_name') and 
+            m._get_name() in PYTORCH_QUANTIZED_MODULES
+        ):
+            if hasattr(m, "get_weight"):
+                for weight in m.get_weight().values():
+                    assert weight.dtype == torch.qint8
+                for bias in m.get_bias().values():
+                    assert bias.dtype == torch.float32
+            elif hasattr(m, "_packed_params"):
+                if 'Dynamic' in m._get_name():
+                    assert m._packed_params.dtype == torch.qint8
+                else:
+                    assert m._packed_params.dtype == torch.quint8
+            else:
+                raise NotImplementedError("No _all_weight_values or _packed_params")
+        else:
+            raise NotImplementedError("Quantized modules are not supported yet", m)
+    else:
+        for name, child in children.items():
+            if (
+                hasattr(child, '_get_name') and 
+                child._get_name() in PYTORCH_QUANTIZED_MODULES
+            ):
+                if hasattr(child, "get_weight"):
+                    for weight in child.get_weight().values():
+                        assert weight.dtype == torch.qint8
+                    for bias in child.get_bias().values():
+                        assert bias.dtype == torch.float32
+                elif hasattr(child, "_packed_params"):
+                    if 'Dynamic' in child._get_name():
+                        assert child._packed_params.dtype == torch.qint8
+                    else:
+                        assert child._packed_params.dtype == torch.quint8
+                else:
+                    raise NotImplementedError("No _all_weight_values or _packed_params")
+            else:
+                raise NotImplementedError("Quantized modules are not supported yet", name, child)
+    return True
+
+
+class SingleLayer(torch.nn.Module):
+    def __init__(self, type="linear"):
+        super(SingleLayer, self).__init__()
+        if type == "linear":
+            self.l1 = torch.nn.Linear(12, 1)
+        elif type == "conv2d":
+            self.l1 = torch.nn.Conv2d(1, 1, 3, padding=1)
+        elif type == "conv3d":
+            self.l1 = torch.nn.Conv3d(1, 1, 3, padding=1)
+        elif type == "convtranspose2d":
+            self.l1 = torch.nn.ConvTranspose2d(1, 1, 3, padding=1)
+        elif type == "convtranspose3d":
+            self.l1 = torch.nn.ConvTranspose3d(1, 1, 3, padding=1)
+        elif type == "batchnorm":
+            self.l1 = torch.nn.BatchNorm2d(1)
+        elif type == "instancenorm":
+            self.l1 = torch.nn.InstanceNorm2d(1)
+        elif type == "layernorm":
+            self.l1 = torch.nn.LayerNorm(1)
+        elif type == "embedding":
+            self.l1 = torch.nn.Embedding(1, 1)
+        elif type == "embeddingbag":
+            self.l1 = torch.nn.EmbeddingBag(1, 1)
+        elif type == "rnn":
+            self.l1 = torch.nn.RNNCell(1, 1)
+        elif type == "lstm":
+            self.l1 = torch.nn.LSTMCell(1, 1)
+        elif type == "gru":
+            self.l1 = torch.nn.GRUCell(1, 1)
+        else:
+            raise NotImplementedError(f"type {type} not implemented")
+
+    def forward(self, x):
+        x = self.l1(x)
+        return x
+
+@pytest.mark.parametrize(
+    "type, supported",
+    [
+        # Linear
+        ["linear", True],
+
+        # ConvXd
+        ["conv2d", False],
+        ["conv3d", False],
+        ["convtranspose2d", False],
+        ["convtranspose3d", False],
+
+        # Norms
+        ["batchnorm", False],
+        ["layernorm", False],
+        ["instancenorm", False],
+
+        # Embeddings
+        ["embedding", False],
+        ["embeddingbag", True],
+
+        # RNNs
+        ["rnn", True],
+        ["lstm", True],
+        ["gru", True],
+
+    ])
+def test_quantize_on_single_layer(type, supported):
+    """Tests that the auto_set_backend function works as expected."""
+    import approx
+    model_fp32 = SingleLayer(type=type)
+    approx.auto_set_backend()
+    model_int8 = approx.auto_quantize(model_fp32, pretrained=True)
+    if supported:
+        assert assert_children(model_int8) == True
+    else:
+        with pytest.raises(NotImplementedError):
+            assert_children(model_int8)
+
+class MultiLayers(torch.nn.Module):
+    def __init__(self, type="linear"):
+        super(MultiLayers, self).__init__()
+        self._type = type
+        if type == "linear":
+            self.l1 = torch.nn.Linear(12, 8)
+            self.l2 = torch.nn.Linear(8, 4)
+            self.l3 = torch.nn.Linear(4, 2)
+            self.l4 = torch.nn.Linear(2, 1)
+        elif type == "conv2d":
+            self.l1 = torch.nn.Conv2d(256, 128, 3, padding=1)
+            self.l2 = torch.nn.Conv2d(128, 64, 3, padding=1)
+            self.l3 = torch.nn.Conv2d(64, 32, 3, padding=1)
+            self.l4 = torch.nn.Conv2d(32, 16, 3, padding=1)
+        elif type == "conv3d":
+            self.l1 = torch.nn.Conv3d(256, 128, 3, padding=1)
+            self.l2 = torch.nn.Conv3d(128, 64, 3, padding=1)
+            self.l3 = torch.nn.Conv3d(64, 32, 3, padding=1)
+            self.l4 = torch.nn.Conv3d(32, 16, 3, padding=1)
+        elif type == "convtranspose2d":
+            self.l1 = torch.nn.ConvTranspose2d(16, 32, 3, padding=1)
+            self.l2 = torch.nn.ConvTranspose2d(32, 64, 3, padding=1)
+            self.l3 = torch.nn.ConvTranspose2d(64, 128, 3, padding=1)
+            self.l4 = torch.nn.ConvTranspose2d(128, 256, 3, padding=1)
+        elif type == "convtranspose3d":
+            self.l1 = torch.nn.ConvTranspose3d(16, 32, 3, padding=1)
+            self.l2 = torch.nn.ConvTranspose3d(32, 64, 3, padding=1)
+            self.l3 = torch.nn.ConvTranspose3d(64, 128, 3, padding=1)
+            self.l4 = torch.nn.ConvTranspose3d(128, 256, 3, padding=1)
+        elif type == "batchnorm":
+            self.l1 = torch.nn.Conv2d(256, 128, 3, padding=1)
+            self.l2 = torch.nn.BatchNorm2d(1)
+            self.l3 = torch.nn.Conv2d(128, 64, 3, padding=1)
+            self.l4 = torch.nn.BatchNorm2d(1)
+        elif type == "instancenorm":
+            self.l1 = torch.nn.Conv2d(256, 128, 3, padding=1)
+            self.l2 = torch.nn.InstanceNorm2d(1)
+            self.l3 = torch.nn.Conv2d(128, 64, 3, padding=1)
+            self.l4 = torch.nn.InstanceNorm2d(1)
+        elif type == "layernorm":
+            self.l1 = torch.nn.Conv2d(256, 128, 3, padding=1)
+            self.l2 = torch.nn.LayerNorm(1)
+            self.l3 = torch.nn.Conv2d(128, 64, 3, padding=1)
+            self.l4 = torch.nn.LayerNorm(1)
+        elif type == "embedding":
+            self.l1 = torch.nn.Embedding(1, 1)
+            self.l2 = torch.nn.Embedding(1, 1)
+            self.l3 = torch.nn.Embedding(1, 1)
+            self.l4 = torch.nn.Embedding(1, 1)
+        elif type == "embeddingbag":
+            self.l1 = torch.nn.EmbeddingBag(1, 1)
+            self.l2 = torch.nn.EmbeddingBag(1, 1)
+            self.l3 = torch.nn.EmbeddingBag(1, 1)
+            self.l4 = torch.nn.EmbeddingBag(1, 1)
+        elif type == "rnn":
+            self.l1 = torch.nn.RNNCell(256, 128)
+            self.l2 = torch.nn.RNNCell(128, 64)
+            self.l3 = torch.nn.RNNCell(64, 32)
+            self.l4 = torch.nn.RNNCell(32, 16)
+        elif type == "lstm":
+            self.l1 = torch.nn.LSTMCell(256, 128)
+            self.l2 = torch.nn.LSTMCell(128, 64)
+            self.l3 = torch.nn.LSTMCell(64, 32)
+            self.l4 = torch.nn.LSTMCell(32, 16)
+        elif type == "gru":
+            self.l1 = torch.nn.GRUCell(256, 128)
+            self.l2 = torch.nn.GRUCell(128, 64)
+            self.l3 = torch.nn.GRUCell(64, 32)
+            self.l4 = torch.nn.GRUCell(32, 16)
+        else:
+            raise NotImplementedError(f"type {type} not implemented")
+    def forward(self, x):
+        x = self.l1(x)
+        x = self.l2(x)
+        x = self.l3(x)
+        x = self.l4(x)
+        return x
+
+@pytest.mark.parametrize(
+    "type, supported",
+    [
+        # Linear
+        ["linear", True],
+
+        # ConvXd
+        ["conv2d", False],
+        ["conv3d", False],
+        ["convtranspose2d", False],
+        ["convtranspose3d", False],
+
+        # Norms
+        ["batchnorm", False],
+        ["layernorm", False],
+        ["instancenorm", False],
+
+        # Embeddings
+        ["embedding", False],
+        ["embeddingbag", True],
+
+        # RNNs
+        ["rnn", True],
+        ["lstm", True],
+        ["gru", True],
+
+    ])
+def test_quantize_on_multiple_layer(type, supported):
+    """Tests that the auto_set_backend function works as expected."""
+    import approx
+    model_fp32 = MultiLayers(type=type)
+    approx.auto_set_backend()
+    model_int8 = approx.auto_quantize(model_fp32, pretrained=True)
+    if supported:
+        assert assert_children(model_int8) == True
+    else:
+        with pytest.raises(NotImplementedError):
+            assert_children(model_int8)

--- a/tests/integration/core/test_api.py
+++ b/tests/integration/core/test_api.py
@@ -7,7 +7,7 @@ def test_auto_set_backend():
     """Tests that the auto_set_backend function works as expected."""
     # from approx.core.api import auto_set_backend
     import approx
-    from approx.core.backend._backend import BackendType, BackendEngine
+    from approx.core.backend._backend import BackendEngine
 
     approx.auto_set_backend()
 
@@ -29,7 +29,8 @@ def test_set_backend():
         )
     ]
     for backend_type in backend_types:
-        print(BackendType[backend_type])
+        if backend_type.lower() == "unknown":
+            continue
         backend_engine = set_backend(BackendType[backend_type])
         assert backend_engine.type == BackendType[backend_type]
         assert str(backend_engine) == backend_type.lower()
@@ -49,6 +50,8 @@ def test_set_device():
         )
     ]
     for device_type in device_types:
+        if device_type.lower() == "unknown":
+            continue
         device_engine = set_device(DeviceType[device_type])
         assert device_engine.type == DeviceType[device_type]
         assert str(device_engine) == device_type.lower()

--- a/tests/integration/core/test_api.py
+++ b/tests/integration/core/test_api.py
@@ -5,7 +5,6 @@ Test Public API
 
 def test_auto_set_backend():
     """Tests that the auto_set_backend function works as expected."""
-    # from approx.core.api import auto_set_backend
     import approx
     from approx.core.backend._backend import BackendEngine
 

--- a/tests/integration/core/test_api.py
+++ b/tests/integration/core/test_api.py
@@ -5,12 +5,14 @@ Test Public API
 
 def test_auto_set_backend():
     """Tests that the auto_set_backend function works as expected."""
-    from approx.core.api import auto_set_backend
-    from approx.core.backend._backend import BackendType
+    # from approx.core.api import auto_set_backend
+    import approx
+    from approx.core.backend._backend import BackendType, BackendEngine
 
-    backend_engine = auto_set_backend()
-    assert backend_engine.type == BackendType.NUMPY
-    assert str(backend_engine) == "numpy"
+    approx.auto_set_backend()
+
+    assert isinstance(approx.backend(), BackendEngine)
+    assert str(approx.backend()) == "torch"
 
 
 def test_set_backend():

--- a/tests/integration/core/test_api.py
+++ b/tests/integration/core/test_api.py
@@ -2,7 +2,6 @@
 Test Public API
 """
 
-
 def test_auto_set_backend():
     """Tests that the auto_set_backend function works as expected."""
     import approx

--- a/tests/integration/core/test_api.py
+++ b/tests/integration/core/test_api.py
@@ -2,6 +2,7 @@
 Test Public API
 """
 
+
 def test_auto_set_backend():
     """Tests that the auto_set_backend function works as expected."""
     import approx


### PR DESCRIPTION
This PR adds support for `approx.auto_quantize` as covered in #16.

This function takes some model (currently only torch module) and returns a quantized version of that model

Also changes the function signature of `auto_set_backend()` to modify a library variable instead

Closes: #16 

May also close #3 